### PR TITLE
fix: Revert to not using `gh` to support self-hosted runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Get Version
       shell: bash
       run: |
-        LATEST_VERSION=$(gh release view -R eclipse-apoapsis/ort-server --json tagName --jq .tagName)
+        LATEST_VERSION=$(curl -s https://api.github.com/repos/eclipse-apoapsis/ort-server/releases/latest | jq -r .tag_name)
         [ "$(osc --version)" = "osc version $LATEST_VERSION" ]
     - name: Setup fixed OSC (without Authentication)
       uses: ./setup-osc

--- a/setup-osc/action.yml
+++ b/setup-osc/action.yml
@@ -37,7 +37,7 @@ runs:
         OSC_VERSION: ${{ inputs.osc-version }}
       run: |
         if [ -z "$OSC_VERSION" -o "$OSC_VERSION" = "latest" ]; then
-          OSC_VERSION=$(gh release view -R eclipse-apoapsis/ort-server --json tagName --jq .tagName)
+          OSC_VERSION=$(curl -s https://api.github.com/repos/eclipse-apoapsis/ort-server/releases/latest | jq -r .tag_name)
         fi
 
         OSC_HOME=$RUNNER_TOOL_CACHE/osc/$OSC_VERSION
@@ -48,14 +48,13 @@ runs:
 
           echo "::notice::Setting up OSC version $OSC_VERSION ($LOWERCASE_OS-$LOWERCASE_ARCH) in '$OSC_HOME'..."
 
-          # https://cli.github.com/manual/gh_release_download
-          gh release download $OSC_VERSION -R eclipse-apoapsis/ort-server -p osc-cli-$LOWERCASE_OS-$LOWERCASE_ARCH*
-
           mkdir -p "$OSC_HOME"
 
           if [ "$LOWERCASE_OS" = "windows" ]; then
+            curl -LO https://github.com/eclipse-apoapsis/ort-server/releases/download/$OSC_VERSION/osc-cli-$LOWERCASE_OS-$LOWERCASE_ARCH.zip
             unzip osc-cli-$LOWERCASE_OS-$LOWERCASE_ARCH.zip -d "$OSC_HOME"
           else
+            curl -LO https://github.com/eclipse-apoapsis/ort-server/releases/download/$OSC_VERSION/osc-cli-$LOWERCASE_OS-$LOWERCASE_ARCH.tar.gz
             tar -xzf osc-cli-$LOWERCASE_OS-$LOWERCASE_ARCH.tar.gz -C "$OSC_HOME"
           fi
 


### PR DESCRIPTION
An alternative would have been to install `gh`, but installations instructions are platform-specific, and all actions found to do that had no releases for several years. So rather just use `curl` again, like before f057fef.