### PR TITLE
feat: Allow to override the GitHub token

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ The action can be configured to use authentication with the ORT Server instance 
                Only required if using a custom Keycloak instance.
 - `client-id`: The client ID to use for authentication (optional).
                Only required if using a custom Keycloak instance.
+- `github-token`: The github.com token to override the usage of `${{ github.token }}` (optional).

--- a/setup-osc/action.yml
+++ b/setup-osc/action.yml
@@ -20,6 +20,13 @@ inputs:
   client-id:
     description: 'The client ID to authenticate with the ORT Server instance'
     required: false
+  github-token:
+    description: |
+      The GitHub token to use for accessing releases on github.com. Defaults to the github.token property.
+      On GitHub Enterprise Server (GHES), use a Personal Access Token (PAT) with 'public_repo' scope instead.
+      Can be set to empty string to use unauthenticated access (may hit rate limits).
+    required: false
+    default: ${{ github.token }}
 outputs:
   osc-cached:
     description: 'A boolean flag to indicate whether the OSC tool was already cached'
@@ -33,7 +40,7 @@ runs:
       id: download-osc
       shell: bash
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.github-token }}
         OSC_VERSION: ${{ inputs.osc-version }}
       run: |
         if [ -z "$OSC_VERSION" -o "$OSC_VERSION" = "latest" ]; then


### PR DESCRIPTION
If the `setup-osc` action is used from GHES [1], we cannot rely on `${{ github.token }}` to be a valid token for accessing releases from github.com.
Allow overriding this token with a custom github.com token or disabling authenticated access to github.com releases (which may hit rate limits).

[1]: https://docs.github.com/en/enterprise-server@3.19/admin/overview/about-github-enterprise-server

Resolves: #22.