### PR TITLE
fix(setup-osc): Deal with passwords that contain double-quotes

### DIFF
--- a/setup-osc/action.yml
+++ b/setup-osc/action.yml
@@ -85,6 +85,9 @@ runs:
     - name: Configure Authentication
       if: ${{ inputs.url != '' && inputs.username != '' && inputs.password != '' }}
       shell: bash
+      env:
+        USERNAME: ${{ inputs.username }}
+        PASSWORD: ${{ inputs.password }}
       run: |
         TOKEN_URL_ARG=""
         if [[ -n "${{ inputs.token-url }}" ]]; then
@@ -98,8 +101,8 @@ runs:
 
         osc auth login \
           --url "${{ inputs.url }}" \
-          --username "${{ inputs.username }}" \
-          --password "${{ inputs.password }}" \
+          --username "$USERNAME" \
+          --password "$PASSWORD" \
           $TOKEN_URL_ARG \
           $CLIENT_ID_ARG
 


### PR DESCRIPTION
First mapping to environment variables solves the problem for passwords and usernames.

Fixes #26.