### PR TITLE
Remove the usage of the GitHub API to avoid rate limiting

### DIFF
--- a/setup-osc/action.yml
+++ b/setup-osc/action.yml
@@ -20,13 +20,6 @@ inputs:
   client-id:
     description: 'The client ID to authenticate with the ORT Server instance'
     required: false
-  github-token:
-    description: |
-      The GitHub token to use for accessing releases on github.com. Defaults to the github.token property.
-      On GitHub Enterprise Server (GHES), use a Personal Access Token (PAT) with 'public_repo' scope instead.
-      Can be set to empty string to use unauthenticated access (may hit rate limits).
-    required: false
-    default: ${{ github.token }}
 outputs:
   osc-cached:
     description: 'A boolean flag to indicate whether the OSC tool was already cached'
@@ -40,15 +33,8 @@ runs:
       id: download-osc
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github-token }}
         OSC_VERSION: ${{ inputs.osc-version }}
       run: |
-        if [ -n "$GH_TOKEN" ]; then
-          AUTH_HEADER="Authorization: token $GH_TOKEN"
-        else
-          AUTH_HEADER=""
-        fi
-
         if [[ -z "$OSC_VERSION" || "$OSC_VERSION" = "latest" ]]; then
           OSC_VERSION=$(curl -sI https://github.com/eclipse-apoapsis/ort-server/releases/latest \
             | grep -i "location" | sed 's,.*/tag/,,' | tr -d '\r\n')
@@ -82,7 +68,7 @@ runs:
 
           DOWNLOAD_URL="https://github.com/eclipse-apoapsis/ort-server/releases/download/$OSC_VERSION/$ASSET_NAME"
 
-          curl -sL ${AUTH_HEADER:+-H "$AUTH_HEADER"} -o "$ASSET_NAME" "$DOWNLOAD_URL"
+          curl -sL -o "$ASSET_NAME" "$DOWNLOAD_URL"
 
           if [ "$LOWERCASE_OS" = "windows" ]; then
             unzip "$ASSET_NAME" -d "$OSC_HOME"

--- a/setup-osc/action.yml
+++ b/setup-osc/action.yml
@@ -49,13 +49,13 @@ runs:
           AUTH_HEADER=""
         fi
 
-        if [ -z "$OSC_VERSION" -o "$OSC_VERSION" = "latest" ]; then
+        if [[ -z "$OSC_VERSION" || "$OSC_VERSION" = "latest" ]]; then
           OSC_VERSION=$(curl -s ${AUTH_HEADER:+-H "$AUTH_HEADER"} \
             https://api.github.com/repos/eclipse-apoapsis/ort-server/releases/latest \
             | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
         fi
 
-        if [ -z "$OSC_VERSION" -o "$OSC_VERSION" = "null" ]; then
+        if [[ -z "$OSC_VERSION" || "$OSC_VERSION" = "null" ]]; then
           echo "::error::Failed to get the latest OSC version."
           exit 1
         fi

--- a/setup-osc/action.yml
+++ b/setup-osc/action.yml
@@ -50,9 +50,13 @@ runs:
         fi
 
         if [[ -z "$OSC_VERSION" || "$OSC_VERSION" = "latest" ]]; then
-          OSC_VERSION=$(curl -s ${AUTH_HEADER:+-H "$AUTH_HEADER"} \
-            https://api.github.com/repos/eclipse-apoapsis/ort-server/releases/latest \
-            | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
+          OSC_VERSION=$(curl -sI https://github.com/eclipse-apoapsis/ort-server/releases/latest \
+            | grep -i "location" | sed 's,.*/tag/,,' | tr -d '\r\n')
+        
+          if [ -z "$OSC_VERSION" ]; then
+            echo "::error::Failed to get the latest OSC version."
+            exit 1
+          fi
         fi
 
         if [[ -z "$OSC_VERSION" || "$OSC_VERSION" = "null" ]]; then


### PR DESCRIPTION
Unfortunately, https://github.com/eclipse-apoapsis/actions/pull/13 introduced multiple issues when running the action on GHES or on self-hosted runners.
1. `gh` might not be available on self-hosted runners
2. Authentication to `github.com` when running on GHES is cumbersome and requires a separate `github.com` account.

1\) was already solved by https://github.com/eclipse-apoapsis/actions/pull/31, but 2) remains an issue.
Revert to the approach that was used before #13 to download `latest` from `/releases/latest/download/...`.

This has the drawback that we won't know the version of `latest` before downloading it, and therefore (version based) caching becomes impossible.