### PR TITLE
fix(setup-osc): URL-encode credentials in token request

### DIFF
--- a/setup-osc/action.yml
+++ b/setup-osc/action.yml
@@ -85,8 +85,8 @@ runs:
         TOKEN_RESPONSE=$(curl -s -X POST "$TOKEN_URL" \
           -H "Content-Type: application/x-www-form-urlencoded" \
           -d "grant_type=password" \
-          -d "username=$USERNAME" \
-          -d "password=$PASSWORD" \
+          --data-urlencode "username=$USERNAME" \
+          --data-urlencode "password=$PASSWORD" \
           -d "client_id=$CLIENT_ID")
 
         # Extract access token.


### PR DESCRIPTION
This ensures that special characters in the credentials are sent correctly. For example a username like `some+user` was received as `some user` and so the user was not found.