### PR TITLE
fix(setup-osc): Trim a suffix from the server version for the OSC version

### DIFF
--- a/setup-osc/action.yml
+++ b/setup-osc/action.yml
@@ -127,7 +127,7 @@ runs:
             echo "::error::Server version not set."
             exit 1
           fi
-          OSC_VERSION="$SERVER_VERSION"
+          OSC_VERSION="${SERVER_VERSION%%-}"
         elif [[ -z "$OSC_VERSION" || "$OSC_VERSION" = "latest" ]]; then
           OSC_VERSION=$(curl -sI https://github.com/eclipse-apoapsis/ort-server/releases/latest \
             | grep -i "location" | sed 's,.*/tag/,,' | tr -d '\r\n')


### PR DESCRIPTION
Currently, the server's version as shown in the about dialog is something like "0.68.0-RC.030.sha.97c3b2c" although commit `97c3b2c` is exactly what the 0.68.0 tag points to. To be able to download a matching OSC release from GitHub, the suffix needs to be stripped.

Relates to #38.