### PR TITLE
fix(setup-osc): Strip the full suffix from the server version

### DIFF
--- a/setup-osc/action.yml
+++ b/setup-osc/action.yml
@@ -127,7 +127,7 @@ runs:
             echo "::error::Server version not set."
             exit 1
           fi
-          OSC_VERSION="${SERVER_VERSION%%-}"
+          OSC_VERSION="${SERVER_VERSION%%-*}"
         elif [[ -z "$OSC_VERSION" || "$OSC_VERSION" = "latest" ]]; then
           OSC_VERSION=$(curl -sI https://github.com/eclipse-apoapsis/ort-server/releases/latest \
             | grep -i "location" | sed 's,.*/tag/,,' | tr -d '\r\n')


### PR DESCRIPTION
The previous trimming logic used `${SERVER_VERSION%%-}`, which only removes a trailing `-` character.

Use `${SERVER_VERSION%%-*}` instead so that everything from the first `-` onward is removed. This turns a server version like `0.68.0-RC.030.sha.97c3b2c` into `0.68.0`, which matches the GitHub release tag used to download OSC.

This is a fixup for [463064a](https://github.com/eclipse-apoapsis/actions/commit/463064aa1e7efc8d5a0eeee24fedd0f6c810feac).